### PR TITLE
Add labels to posts

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -55,6 +55,22 @@ class PostsController < ApplicationController
   end
 
   def post_params
-    params.require(:post).permit(:title, :content, :author)
+    permitted_params = params.require(:post).permit(:title, :content, :author, :labels)
+    
+    # Process labels from comma-separated string to array
+    if permitted_params[:labels].present?
+      if permitted_params[:labels].is_a?(String)
+        # Convert comma-separated string to array
+        permitted_params[:labels] = permitted_params[:labels].split(',').map(&:strip).reject(&:blank?)
+      else
+        # Already an array, just clean it up
+        permitted_params[:labels] = permitted_params[:labels].reject(&:blank?)
+      end
+    else
+      # Ensure empty labels is an empty array
+      permitted_params[:labels] = []
+    end
+    
+    permitted_params
   end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -3,8 +3,14 @@ class Post < ApplicationRecord
   validates :content, presence: true
   validates :author, presence: true
 
+  # Serialize labels as JSON array
+  serialize :labels, coder: JSON
+
   scope :published, -> { where.not(published_at: nil) }
   scope :recent, -> { order(created_at: :desc) }
+
+  # Initialize labels as empty array if nil
+  after_initialize :set_default_labels
 
   def published?
     published_at.present?
@@ -16,5 +22,19 @@ class Post < ApplicationRecord
 
   def unpublish!
     update(published_at: nil)
+  end
+
+  def add_label(label)
+    self.labels = (labels || []) << label.strip unless label.blank? || labels&.include?(label.strip)
+  end
+
+  def remove_label(label)
+    self.labels = (labels || []).reject { |l| l == label.strip }
+  end
+
+  private
+
+  def set_default_labels
+    self.labels ||= []
   end
 end

--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -31,6 +31,16 @@
     </div>
 
     <div class="form-group">
+      <%= form.label :labels, "Labels (comma-separated)", class: "form-label" %>
+      <%= form.text_field :labels, 
+          value: (@post.labels || []).join(', '), 
+          class: "form-control", 
+          placeholder: "e.g. tech, tutorial, announcement",
+          id: "labels_input" %>
+      <small class="form-text">Enter labels separated by commas</small>
+    </div>
+
+    <div class="form-group">
       <%= form.label :content, class: "form-label" %>
       <%= form.text_area :content, class: "form-control", rows: 15, placeholder: "Write your post content here..." %>
     </div>
@@ -105,6 +115,12 @@
     outline: none;
     border-color: #0066cc;
     box-shadow: 0 0 0 2px rgba(0, 102, 204, 0.2);
+  }
+  
+  .form-text {
+    font-size: 14px;
+    color: #666;
+    margin-top: 5px;
   }
   
   textarea.form-control {

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -21,6 +21,14 @@
                 <span class="status draft">Draft</span>
               <% end %>
             </div>
+            
+            <% if post.labels.present? %>
+              <div class="post-labels">
+                <% post.labels.each do |label| %>
+                  <span class="label-tag"><%= label %></span>
+                <% end %>
+              </div>
+            <% end %>
           </div>
           
           <div class="post-content">
@@ -104,6 +112,23 @@
   .status.draft {
     background: #fff3cd;
     color: #856404;
+  }
+  
+  .post-labels {
+    margin-top: 10px;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+  }
+  
+  .label-tag {
+    display: inline-block;
+    background: #e9ecef;
+    color: #495057;
+    padding: 2px 6px;
+    border-radius: 8px;
+    font-size: 11px;
+    font-weight: 500;
   }
   
   .post-content {

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -30,6 +30,16 @@
     </div>
 
     <div class="form-group">
+      <%= form.label :labels, "Labels (comma-separated)", class: "form-label" %>
+      <%= form.text_field :labels, 
+          value: (@post.labels || []).join(', '), 
+          class: "form-control", 
+          placeholder: "e.g. tech, tutorial, announcement",
+          id: "labels_input" %>
+      <small class="form-text">Enter labels separated by commas</small>
+    </div>
+
+    <div class="form-group">
       <%= form.label :content, class: "form-label" %>
       <%= form.text_area :content, class: "form-control", rows: 15, placeholder: "Write your post content here..." %>
     </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -17,6 +17,14 @@
           <span class="status draft">Draft</span>
         <% end %>
       </div>
+      
+      <% if @post.labels.present? %>
+        <div class="post-labels">
+          <% @post.labels.each do |label| %>
+            <span class="label-tag"><%= label %></span>
+          <% end %>
+        </div>
+      <% end %>
     </header>
     
     <div class="post-content">
@@ -102,6 +110,23 @@
   .status.draft {
     background: #fff3cd;
     color: #856404;
+  }
+  
+  .post-labels {
+    margin-top: 15px;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+  
+  .label-tag {
+    display: inline-block;
+    background: #e9ecef;
+    color: #495057;
+    padding: 4px 8px;
+    border-radius: 12px;
+    font-size: 12px;
+    font-weight: 500;
   }
   
   .post-content {

--- a/db/migrate/20250604185115_add_labels_to_posts.rb
+++ b/db/migrate/20250604185115_add_labels_to_posts.rb
@@ -1,0 +1,5 @@
+class AddLabelsToPosts < ActiveRecord::Migration[7.1]
+  def change
+    add_column :posts, :labels, :text, default: '[]'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_06_04_181638) do
+ActiveRecord::Schema[7.1].define(version: 2025_06_04_185115) do
   create_table "posts", force: :cascade do |t|
     t.string "title"
     t.text "content"
@@ -18,6 +18,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_06_04_181638) do
     t.datetime "published_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.text "labels", default: "[]"
   end
 
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -11,7 +11,8 @@ This platform allows authors to write, edit, and publish posts with a simple and
 
 Stay tuned for more exciting content!",
     author: "Admin",
-    published_at: 1.day.ago
+    published_at: 1.day.ago,
+    labels: ["welcome", "announcement", "blog"]
   },
   {
     title: "Getting Started with Rails",
@@ -25,7 +26,8 @@ Here are some key benefits of Rails:
 
 Whether you're building a simple blog or a complex web application, Rails provides the tools you need to get started quickly.",
     author: "Developer",
-    published_at: 2.hours.ago
+    published_at: 2.hours.ago,
+    labels: ["rails", "tutorial", "programming", "web-development"]
   },
   {
     title: "Draft Post Example",
@@ -37,7 +39,8 @@ Draft posts are useful for:
 - Scheduling future content
 
 You can easily publish this post when you're ready!",
-    author: "Content Writer"
+    author: "Content Writer",
+    labels: ["draft", "example"]
     # Note: no published_at date, so this remains a draft
   }
 ])

--- a/test/models/post_test.rb
+++ b/test/models/post_test.rb
@@ -40,4 +40,51 @@ class PostTest < ActiveSupport::TestCase
     assert_not post.published?
     assert_nil post.published_at
   end
+
+  test "should initialize with empty labels array" do
+    post = Post.new
+    assert_equal [], post.labels
+  end
+
+  test "should serialize labels as JSON array" do
+    post = Post.create!(title: "Test", content: "Content", author: "Author", labels: ["tech", "rails"])
+    assert_equal ["tech", "rails"], post.labels
+
+    # Reload from database to ensure serialization works
+    post.reload
+    assert_equal ["tech", "rails"], post.labels
+  end
+
+  test "should handle empty labels" do
+    post = Post.create!(title: "Test", content: "Content", author: "Author", labels: [])
+    assert_equal [], post.labels
+  end
+
+  test "should add labels" do
+    post = Post.new(title: "Test", content: "Content", author: "Author")
+    post.add_label("tech")
+    post.add_label("rails")
+    assert_equal ["tech", "rails"], post.labels
+  end
+
+  test "should not add duplicate labels" do
+    post = Post.new(title: "Test", content: "Content", author: "Author")
+    post.add_label("tech")
+    post.add_label("tech")
+    assert_equal ["tech"], post.labels
+  end
+
+  test "should remove labels" do
+    post = Post.new(title: "Test", content: "Content", author: "Author", labels: ["tech", "rails", "tutorial"])
+    post.remove_label("rails")
+    assert_equal ["tech", "tutorial"], post.labels
+  end
+
+  test "should handle blank labels gracefully" do
+    post = Post.new(title: "Test", content: "Content", author: "Author")
+    post.add_label("")
+    post.add_label("  ")
+    post.add_label(nil)
+    assert_equal [], post.labels
+  end
 end


### PR DESCRIPTION
This PR is opened as is a simple test of a "documentation drift detection" Actions workflow running against PRs. It analyzes docs in the repo, finding candidates via `.github/docs-knowledge-base.json` file and assessing them against the diff. (This leading PR description is not currently factored into the prompts for the proof-of-concept).

The changes here add a field to a model/DB table in a sample Rails app, and we hope that the workflow notices that certain documentation needs updating!